### PR TITLE
Fix zero appid bugs

### DIFF
--- a/domain/src/main/java/bruhcollective/itaysonlab/jetisteam/usecases/profile/GetProfileData.kt
+++ b/domain/src/main/java/bruhcollective/itaysonlab/jetisteam/usecases/profile/GetProfileData.kt
@@ -49,6 +49,7 @@ class GetProfileData @Inject constructor(
             .map { it.slots }
             .flatten()
             .map { it.appId }
+            .filter { it > 0 } // some slots appids might be zero
 
         val recentGames = ownedGames
             .sortedByDescending { it.rtime_last_played }


### PR DESCRIPTION
Стим кажется любит присылать appid: 0 в различных ответах

Первый коммит исправляет вот этот баг:  
![screenshot](https://user-images.githubusercontent.com/17468894/204084172-e91eb97c-0dd6-4019-ad17-603d6470dbd5.png)

Второй коммит исправляет баг на моем аккаунте:
```
java.lang.NullPointerException
	at bruhcollective.itaysonlab.jetisteam.usecases.GetNotifications$invoke$2.invokeSuspend(GetNotifications.kt:82)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```
Там тоже приходит appid: 0 в нотификейшене и из-за этого не может найти игру в списке `games`